### PR TITLE
simplify if-statement boolean logic

### DIFF
--- a/main.go
+++ b/main.go
@@ -128,11 +128,8 @@ func update(screen *ebiten.Image) error {
 
 	ix := 0
 	for _, proj := range projectiles {
-		if proj.Position.X < -10 ||
-			proj.Position.X > screenWidth+10 ||
-			proj.Position.Y < -10 ||
-			proj.Position.Y > screenHeight+10 {
-		} else {
+		if -10 <= proj.Position.X && proj.Position.X <= screenWidth+10 &&
+			-10 <= proj.Position.Y && proj.Position.Y <= screenHeight+10 {
 			projectiles[ix] = proj
 			ix++
 		}


### PR DESCRIPTION
The previous version used an if-statement with an empty body,
where only the else-branch did any work. This PR flippes the
condition, which can now be read as:

	(-10 <= x <= width+10) && (-10 <= y <= height+10)